### PR TITLE
Update .gitignore and README.md with improved instructions for managing dotfiles using Stow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,35 +1,67 @@
-# dotfiles
+# Dotfiles
+-------------------
+
 This section contains the dotfiles, which are Linux configuration files used to customize builds. Stow is utilized to create symbolic links and place the dotfiles in their appropriate locations.
 
-# Stow
+## Overview 
 
 Stow is a symlink farm manager which takes distinct packages of software and/or data located in separate directories on the filesystem, and makes them appear to be installed in the same place.
 
-## Installation via Package Manager
+## *Table of Contents*
 
-### Ubuntu
+- [Dotfiles](#dotfiles)
+  - [Overview](#overview)
+  - [*Table of Contents*](#table-of-contents)
+  - [Installation](#installation)
+    - [Via Package Manager](#via-package-manager)
+      - [Ubuntu](#ubuntu)
+      - [MacOS](#macos)
+      - [Fedora](#fedora)
+    - [Installation via Source Code](#installation-via-source-code)
+      - [Downloading the latest tarball](#downloading-the-latest-tarball)
+      - [Create a dotfiles folder in the home directory](#create-a-dotfiles-folder-in-the-home-directory)
+      - [*Moving dotfiles to the hidden dotfiles folder (Optional)*](#moving-dotfiles-to-the-hidden-dotfiles-folder-optional)
+  - [Usage](#usage)
+    - [Linking files in the dotfiles folder](#linking-files-in-the-dotfiles-folder)
+    - [Preparing the dotfiles folder before linking the files](#preparing-the-dotfiles-folder-before-linking-the-files)
+    - [Unlinking files in the dotfiles folder](#unlinking-files-in-the-dotfiles-folder)
+  - [Examples](#examples)
+    - [Managing dotfiles with Git across multiple machines](#managing-dotfiles-with-git-across-multiple-machines)
+    - [Syncing dotfiles across multiple machines](#syncing-dotfiles-across-multiple-machines)
+    - [Example bash script for automating the sync process](#example-bash-script-for-automating-the-sync-process)
+  - [References](#references)
+
+
+
+
+## Installation 
+
+### Via Package Manager
+
+#### Ubuntu
 ```bash
 sudo apt-get update
 sudo apt-get install stow
 ```
 
-### MacOS
+#### MacOS
 
 ```bash
 brew install stow
 ```
 
-### Fedora
+#### Fedora
 
 ```bash
 sudo dnf install stow
 ```
 
-## Installation via Source Code
+### Installation via Source Code
 
 The latest available stow version is the 2.4.0 since 2021-07-25. The tarball is available for download here: https://ftp.gnu.org/gnu/stow/
 
 
+#### Downloading the latest tarball
 You can download the latest tarball using the following command via wget. The tarball will be downloaded to the Downloads directory. You can change the directory to your preferred location if needed.:
 
 ``` bash
@@ -51,7 +83,20 @@ make
 sudo make install
 ```
 
-## Moving dotfiles to the hidden dotfiles folder (Optional)
+You can verify the installation by running the following command:
+```bash
+stow --version
+```
+
+#### Create a dotfiles folder in the home directory
+
+Create a dotfiles folder in the home directory to store the configuration files. You can create the folder using the following command:
+
+`mkdir ~/.dotfiles`
+
+
+
+#### *Moving dotfiles to the hidden dotfiles folder (Optional)*
 `mv ~/dotfiles ~/.dotfiles` 
 
 For the purpose of this guide, we will assume that the dotfiles folder is located in the home directory. If the dotfiles folder is located elsewhere, replace `~/.dotfiles` with the appropriate path.
@@ -86,14 +131,14 @@ You can use the following commands to create the directory structure in the dotf
 
 This command will create symbolic links in the home directory to the files in the `~/.dotfiles/vim` directory.
 
-## Unlinking files in the dotfiles folder
+### Unlinking files in the dotfiles folder
 
 `stow -d ~/.dotfiles -t ~ -D {PATH/TO/FILE}`
 > Note: Replace `{PATH/TO/FILE}` with the path of the file you want to unlink. The command will remove the symbolic links in the home directory to the files in the dotfiles folder.
 
 
 
-## Example
+## Examples
 For example, let's say you want to manage your `.vimrc` file using stow. You would create a directory structure in the dotfiles folder that mirrors the home directory structure. You would then move the `.vimrc` file to the appropriate directory in the dotfiles folder and use the stow command to link it to the home directory.
 
 Here is an example of the directory structure in the dotfiles folder:
@@ -119,7 +164,7 @@ This allows you to keep all your configuration files in one place and easily man
 stow -d ~/.dotfiles -t ~ -S vim
 ```
 
-## Managing dotfiles with Git across multiple machines
+### Managing dotfiles with Git across multiple machines
 
 If you want to manage your dotfiles across multiple machines using Git, you can create a Git repository for your dotfiles and use stow to manage the symbolic links.
 
@@ -148,7 +193,7 @@ git push -u origin master
 
 Now you can clone the repository on other machines and use stow to manage the symbolic links to your dotfiles.
 
-## Syncing dotfiles across multiple machines
+### Syncing dotfiles across multiple machines
 
 
 If you want to sync your dotfiles across multiple machines, you can create a script that pulls the latest changes from the repository and uses stow to manage the symbolic links.
@@ -177,14 +222,15 @@ stow -d ~/.dotfiles -t ~ -S bash
 > - Replace `<remote-repository-url>` with the URL of your remote Git repository if you are using a remote repository.
 > - Make sure that the script is executable by running `chmod +x sync-dotfiles.sh` before you can run it as a shell script.
 
-## Example bash script for automating the sync process
+### Example bash script for automating the sync process
 Here is an [example bash script](./.bin/sync-dotfiles.sh) of how you can clone the repository and use stow to manage the symbolic links:
 
 You can run this script on each machine to sync your dotfiles and manage the symbolic links using stow.
 
 
 
-# References
+## References
 - https://www.gnu.org/software/stow/
 - https://www.gnu.org/software/stow/manual/stow.html
 - https://systemcrafters.net/managing-your-dotfiles/using-gnu-stow/
+

--- a/README.md
+++ b/README.md
@@ -18,17 +18,11 @@ Stow is a symlink farm manager which takes distinct packages of software and/or 
       - [MacOS](#macos)
       - [Fedora](#fedora)
     - [Installation via Source Code](#installation-via-source-code)
-      - [Downloading the latest tarball](#downloading-the-latest-tarball)
-      - [Create a dotfiles folder in the home directory](#create-a-dotfiles-folder-in-the-home-directory)
-      - [*Moving dotfiles to the hidden dotfiles folder (Optional)*](#moving-dotfiles-to-the-hidden-dotfiles-folder-optional)
   - [Usage](#usage)
     - [Linking files in the dotfiles folder](#linking-files-in-the-dotfiles-folder)
     - [Preparing the dotfiles folder before linking the files](#preparing-the-dotfiles-folder-before-linking-the-files)
     - [Unlinking files in the dotfiles folder](#unlinking-files-in-the-dotfiles-folder)
   - [Examples](#examples)
-    - [Managing dotfiles with Git across multiple machines](#managing-dotfiles-with-git-across-multiple-machines)
-    - [Syncing dotfiles across multiple machines](#syncing-dotfiles-across-multiple-machines)
-    - [Example bash script for automating the sync process](#example-bash-script-for-automating-the-sync-process)
   - [References](#references)
 
 
@@ -61,7 +55,7 @@ sudo dnf install stow
 The latest available stow version is the 2.4.0 since 2021-07-25. The tarball is available for download here: https://ftp.gnu.org/gnu/stow/
 
 
-#### Downloading the latest tarball
+- Downloading the latest tarball
 You can download the latest tarball using the following command via wget. The tarball will be downloaded to the Downloads directory. You can change the directory to your preferred location if needed.:
 
 ``` bash
@@ -88,7 +82,7 @@ You can verify the installation by running the following command:
 stow --version
 ```
 
-#### Create a dotfiles folder in the home directory
+- Create a dotfiles folder in the home directory
 
 Create a dotfiles folder in the home directory to store the configuration files. You can create the folder using the following command:
 
@@ -96,7 +90,7 @@ Create a dotfiles folder in the home directory to store the configuration files.
 
 
 
-#### *Moving dotfiles to the hidden dotfiles folder (Optional)*
+- *Moving dotfiles to the hidden dotfiles folder (Optional)*
 `mv ~/dotfiles ~/.dotfiles` 
 
 For the purpose of this guide, we will assume that the dotfiles folder is located in the home directory. If the dotfiles folder is located elsewhere, replace `~/.dotfiles` with the appropriate path.
@@ -164,7 +158,7 @@ This allows you to keep all your configuration files in one place and easily man
 stow -d ~/.dotfiles -t ~ -S vim
 ```
 
-### Managing dotfiles with Git across multiple machines
+-  Managing dotfiles with Git across multiple machines
 
 If you want to manage your dotfiles across multiple machines using Git, you can create a Git repository for your dotfiles and use stow to manage the symbolic links.
 
@@ -193,7 +187,7 @@ git push -u origin master
 
 Now you can clone the repository on other machines and use stow to manage the symbolic links to your dotfiles.
 
-### Syncing dotfiles across multiple machines
+-  Syncing dotfiles across multiple machines
 
 
 If you want to sync your dotfiles across multiple machines, you can create a script that pulls the latest changes from the repository and uses stow to manage the symbolic links.
@@ -222,7 +216,7 @@ stow -d ~/.dotfiles -t ~ -S bash
 > - Replace `<remote-repository-url>` with the URL of your remote Git repository if you are using a remote repository.
 > - Make sure that the script is executable by running `chmod +x sync-dotfiles.sh` before you can run it as a shell script.
 
-### Example bash script for automating the sync process
+-  Example bash script for automating the sync process
 Here is an [example bash script](./.bin/sync-dotfiles.sh) of how you can clone the repository and use stow to manage the symbolic links:
 
 You can run this script on each machine to sync your dotfiles and manage the symbolic links using stow.


### PR DESCRIPTION
This pull request includes two commits:

1. Add .DS_Store to .gitignore

2. Update README.md with improved instructions for managing dotfiles using Stow

The README.md file has been updated with more detailed instructions on how to install Stow via package manager or source code. It also includes usage examples, such as linking and unlinking files in the dotfiles folder, managing dotfiles with Git across multiple machines, and syncing dotfiles across multiple machines.

Please review and merge these changes.